### PR TITLE
Allow matching on a regular expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ factory'. For efficient usage, it is best to create a variable alias for the fac
   p.optionally(t): tries to parse t; whether it matches or not, this term always matches
 * p.either(a, b, c): matches when either a, b or c successfully matches. The parser tries terms in the order specified.
 * p.kleene(k): matches any number of k 
-
+* p.regex(regex, example): matches if the regular expression matches.
 
 ## Contact
 - Tommy van der Vorst

--- a/test/regexTerm.js
+++ b/test/regexTerm.js
@@ -1,0 +1,68 @@
+var ll = require("../index");
+var p = ll.Factory;
+
+require('should');
+
+describe('Regex term', () => {
+    
+    var g = new ll.Grammar();
+    g.addRule(
+        'playingCard', 
+        p.regex(/^[AKQJT98765432][SHDC]/, 'KH'),
+        true);
+    
+    it('should parse true', done => {
+        var reader = new ll.Reader("TH");
+        var script = [];
+        g.parse(reader, script, function(ok) {
+            ok.should.equal(true);
+            done();
+        });
+    });
+    
+    it('should parse false', done => {
+        var reader = new ll.Reader("10H");
+        var script = [];
+        g.parse(reader, script, function(ok) {
+            ok.should.equal(false);
+            done();
+        });
+    });
+
+    it('should push the matched string', done => {
+        var reader = new ll.Reader("2C");
+        var script = [];
+        g.parse(reader, script, function(ok) {
+            var stack = [];
+            function step() {
+                var f = script.shift();
+                if(f) {
+                    f(stack, step);
+                } else {
+                    stack.length.should.equal(1);
+                    stack.pop().should.equal('2C');
+                    done();
+                }
+            }
+            step(script);
+        });
+    });
+    
+    it('should dump all properties', done => {
+        g.dump((e, dump) => {
+            dump.should.have.property('playingCard');
+            var rule = dump.playingCard;
+            rule.should.have.property('regex');
+            rule.should.have.property('example')
+            done();
+        }); 
+    });
+    
+    it('should have an example', done => {
+        g.example((e,s) => {
+            s.should.equal('KH');
+            done();
+        });
+    });
+
+});


### PR DESCRIPTION
Sometimes it is useful to employ a `regex` instead of a `sequence` of keywords.  My example is a rule that parses the playing cards.

``` javascript
 g.addRule(
    'playingCard', 
    p.regex(/^[AKQJT98765432][SHDC]/, 'KH'),
);
```
